### PR TITLE
fix sync blocking bug when build script times out

### DIFF
--- a/paas-ce/paasagent/job/job.go
+++ b/paas-ce/paasagent/job/job.go
@@ -295,7 +295,9 @@ func (appJob AppJob) runCmd(envMap map[string]string) error {
 		timeoutStr := fmt.Sprintf("Task execution timeout, and the time is limited to %d seconds\r\n", timeOutSeconds)
 		postEventLog(appJob.AppCode, appJob.EventID, &EventLog{Status: core.FAILURE, Log: timeoutStr})
 		log.Println("Deployment task execution timeout")
-		return core.KillCmdProcess(cmd.Process.Pid)
+		core.KillCmdProcess(cmd.Process.Pid)
+		err = <-done
+		return err
 	case err = <-done:
 		if err != nil {
 			postEventLog(appJob.AppCode, appJob.EventID, &EventLog{Status: core.FAILURE, Log: fmt.Sprintf("%s\r\n", err)})


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- 修复当build脚本执行超时后, `done <- cmd.Wait()`阻塞的问题

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)

