### PR TITLE
mysql8.0支持+uwsgi报错+login服务添加依赖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.idea
 
 # C extensions
 *.so

--- a/docs/install/ce_paas_agent_install.md
+++ b/docs/install/ce_paas_agent_install.md
@@ -8,6 +8,7 @@
 - Linux环境
 
 ## 安装部署
+
 PaaSAgent需要部署在满足系统要求的app服务器上。建议最少准备两台服务器，分别用于测试和正式环境
 
 #### 1. 基础环境初始化
@@ -37,7 +38,6 @@ $ ln -s pip3 pip
 $ /opt/py36/bin/python --version
 Python 3.6.7
 ```
-
 
 构建目录及新建用户
 

--- a/paas-ce/paas/appengine/requirements.txt
+++ b/paas-ce/paas/appengine/requirements.txt
@@ -1,6 +1,6 @@
 django==1.8.11
-pymysql==0.6.7
+pymysql==0.9.3
 requests==2.21.0
 gunicorn==19.9.0
-uWSGI==2.0.13.1
+uWSGI==2.0.15
 gevent==1.1.2

--- a/paas-ce/paas/esb/requirements.txt
+++ b/paas-ce/paas/esb/requirements.txt
@@ -4,7 +4,7 @@ Django==1.8.11
 requests==2.21.0
 jinja2==2.8
 sqlalchemy==1.0.12
-pymysql==0.6.7
+pymysql==0.9.3
 redis==2.10.5
 thrift==0.10.0
 gevent==1.1.2
@@ -17,7 +17,7 @@ pycrypto==2.6.1
 
 markdown==2.6.6
 gunicorn==19.9.0
-uWSGI==2.0.13.1
+uWSGI==2.0.15
 PyYAML==5.1
 
 # for fta

--- a/paas-ce/paas/login/requirements.txt
+++ b/paas-ce/paas/login/requirements.txt
@@ -4,7 +4,7 @@ pycrypto==2.6.1
 requests==2.21.0
 pymysql==0.6.7
 gunicorn==19.9.0
-uWSGI==2.0.13.1
+uWSGI==2.0.15
 xlrd==1.0.0
 xlwt==1.1.2
 gevent==1.1.2

--- a/paas-ce/paas/login/requirements.txt
+++ b/paas-ce/paas/login/requirements.txt
@@ -10,3 +10,5 @@ xlwt==1.1.2
 gevent==1.1.2
 pytz==2016.6.1
 python-dateutil==2.6.0
+xlrd==1.2.0
+xlwt==1.1.2

--- a/paas-ce/paas/paas/requirements.txt
+++ b/paas-ce/paas/paas/requirements.txt
@@ -4,9 +4,9 @@ mako==1.0.4
 pycrypto==2.6.1
 requests==2.21.0
 gunicorn==19.9.0
-uWSGI==2.0.13.1
+uWSGI==2.0.15
 elasticsearch==2.3.0
-pymysql==0.6.7
+pymysql==0.9.3
 redis==2.10.5
 PyYAML==5.1
 Pillow==3.4.2

--- a/paas-ce/paas/release.md
+++ b/paas-ce/paas/release.md
@@ -8,8 +8,8 @@
 
 # 3.2.4
 
-- update: python3 frmaework
-- update: python framwork to support https dev
+- update: python3 framework
+- update: python framework to support https dev
 - bugfix: add old login account manager url
 
 # 3.2.3


### PR DESCRIPTION
uwsgi 2.0.13.1版本pip install出错，需升级到2.15以上不报错
mysql8.0驱动pymysql需要升级到最新版本
login服务添加2个依赖包xlrd==1.2.0 xlwt==1.1.2

## 变更点(Changes)
- 更新requirements.txt文件
- release.md中单词错误修正

## 相关issues (Which issues this PR fixes)
- Fixes #181 