### PR TITLE
bugfix: 修复p标签与文字相关组件的对齐问题

### DIFF
--- a/paas-ce/lesscode/lib/client/src/components/render/component-wrapper.js
+++ b/paas-ce/lesscode/lib/client/src/components/render/component-wrapper.js
@@ -38,7 +38,11 @@ export default {
         }, dynamicProps)
 
         const renderStyles = Object.assign({}, renderData.renderStyles)
-        if (componentData.type !== 'img') delete renderStyles.width
+
+        const widthChangeableCompoennts = ['img', 'p', 'span', 'bk-link', 'el-link']
+        if (!widthChangeableCompoennts.includes(componentData.type)) delete renderStyles.width
+
+        console.log('renderStyle', renderStyles)
 
         return h(renderData.type, {
             key: params['component-type'] === 'bk-sideslider' ? 'bk-slider' : refreshKey, // sideSlider 固定key，防止属性修改动画刷新

--- a/paas-ce/lesscode/lib/client/src/element-materials/materials/bk/link/index.js
+++ b/paas-ce/lesscode/lib/client/src/element-materials/materials/bk/link/index.js
@@ -19,7 +19,8 @@ export default {
     events: [{ name: 'click' }],
     styles: ['size', 'margin', 'padding', 'display', 'textAlign'],
     renderStyles: {
-        display: 'inline-block'
+        display: 'inline-block',
+        textAlign: 'center'
     },
     props: {
         theme: {

--- a/paas-ce/lesscode/lib/client/src/element-materials/materials/element/link/index.js
+++ b/paas-ce/lesscode/lib/client/src/element-materials/materials/element/link/index.js
@@ -17,9 +17,10 @@ export default {
     displayName: '文字链接',
     group: '基础',
     events: [{ name: 'click' }],
-    styles: ['size', 'padding', 'margin', 'display'],
+    styles: ['size', 'padding', 'margin', 'display', 'text-align'],
     renderStyles: {
-        display: 'inline-flex'
+        display: 'inline-block',
+        textAlign: 'center'
     },
     props: {
         type: {


### PR DESCRIPTION

- Fixes #

1. 修复p标签外边距过大，画布展示与预览不一致问题；
2. bk-link组件添加text-align属性：
3. bk-text组件添加text-align属性;
4. el-link组件添加text-align属性;

