### PR TITLE
fix: 修复轮播图宽度为100%，但画布里未撑满的问题;修复轮播图动态获取图片地址数据,预览时没有正确渲染的问题

### DIFF
--- a/paas-ce/lesscode/lib/client/src/components/render/component-wrapper.js
+++ b/paas-ce/lesscode/lib/client/src/components/render/component-wrapper.js
@@ -25,8 +25,8 @@ export default {
             } : {}
 
         /** 设置了静态的变量，即使值改变，但不在画布中绑定和渲染 */
-        const rederPropsObj = renderData.renderProps
-        for (const [key, value] of Object.entries(rederPropsObj)) {
+        const renderPropsObj = renderData.renderProps
+        for (const [key, value] of Object.entries(renderPropsObj)) {
             if (Object.prototype.hasOwnProperty.call(value, 'staticValue')) {
                 bindProps[key] = value.staticValue
             }
@@ -53,7 +53,7 @@ export default {
             }
             return acc
         }, {})
-        
+
         return h('span',
             {
                 style: { 'font-size': 'initial' }

--- a/paas-ce/lesscode/lib/client/src/components/render/component.vue
+++ b/paas-ce/lesscode/lib/client/src/components/render/component.vue
@@ -246,7 +246,7 @@
 
             this.updateBindProps()
             this.updateBindSlots()
-            
+
             bus.$on('on-update-props', this.updatePropsHandler)
             this.$once('hook:beforeDestroy', () => {
                 bus.$off('on-update-props', this.updatePropsHandler)
@@ -278,7 +278,7 @@
                     const domNode = this.$refs[this.renderData.componentId].$el
                         || this.$refs[this.renderData.componentId] // 原生html不会有$el元素
                     const componentDisplay = getStyle(domNode, 'display')
-                    
+
                     if (componentDisplay) {
                         if (componentDisplay === 'block') {
                             result = 'block'
@@ -335,6 +335,12 @@
                     bindProps[renderPropsKey] = renderProps[renderPropsKey].val
                 })
                 this.bindProps = bindProps
+
+                // bk-swiper 组件的宽度由属性而不是样式决定，且组件本身的 dom 中会根据对应的属性配置生成 style
+                // 这里强制刷新，让组件重新渲染
+                if (this.renderData.type === 'bk-swiper') {
+                    this.renderDataSlotRefreshKey = Date.now()
+                }
             },
 
             updateBindSlots () {

--- a/paas-ce/lesscode/package.json
+++ b/paas-ce/lesscode/package.json
@@ -105,7 +105,7 @@
     "babel-plugin-syntax-jsx": "~6.18.0",
     "babel-plugin-transform-vue-jsx": "~3.7.0",
     "better-npm-run": "~0.1.1",
-    "bk-magic-vue": "^2.3.4",
+    "bk-magic-vue": "2.3.7-beta.4",
     "caniuse-lite": "~1.0.30000974",
     "chalk": "~2.4.2",
     "change-case": "~4.1.1",


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- fix: 修复轮播图宽度为100%，但画布里未撑满的问题
- fix: 修复轮播图动态获取图片地址数据,预览时没有正确渲染的问题