### PR TITLE
fix issue #1152 ：custom channel in CMSI will be hidden when exec sync…

### DIFF
--- a/paas2/esb/esb/bkcore/managers.py
+++ b/paas2/esb/esb/bkcore/managers.py
@@ -15,8 +15,11 @@ from components.constants import BK_SYSTEMS
 
 
 class ComponentSystemManager(models.Manager):
-    def get_official_ids(self):
-        return list(self.filter(name__in=BK_SYSTEMS.keys()).values_list("id", flat=True))
+    def get_official_ids(self, exclude_names=None):
+        system_objs = self.filter(name__in=BK_SYSTEMS.keys())
+        if exclude_names:
+            system_objs = system_objs.exclude(name__in=exclude_names)
+        return list(system_objs.values_list("id", flat=True))
 
 
 class ESBChannelManager(models.Manager):

--- a/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
+++ b/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
@@ -237,7 +237,8 @@ class Command(BaseCommand):
             self.warning_msgs.append("%s change: %s" % (flag, ", ".join(warning)))
 
     def _get_official_channel_ids(self):
-        official_system_ids = ComponentSystem.objects.get_official_ids()
+        # CMSI下如果有自定义消息通道，会导致自定义通道也被识别为官方通道。因此这里要过滤掉CMSI
+        official_system_ids = ComponentSystem.objects.get_official_ids(exclude_names=["CMSI"])
         return list(
             ESBChannel.objects.filter(component_system_id__in=official_system_ids).values_list("id", flat=True)
         )


### PR DESCRIPTION
…_system_and_channel_data

<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #1152 `.
-->


## 变更点(Changes)

- fix issue #1152 ：custom channel in CMSI will be hidden when exec sync_system_and_channel_data

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)

