### PR TITLE
Fix/issue1152

### DIFF
--- a/paas2/esb/conf/default.py
+++ b/paas2/esb/conf/default.py
@@ -280,5 +280,5 @@ ESB_BUFFET_COMPONENT_CACHE_MAXSIZE = 1000
 ESB_BUFFET_COMPONENT_CACHE_TTL_SECONDS = 300
 
 # 从环境变量获取同步通道数据时豁免的自定义通道列表，格式为：
-# {"CMSI": ["/cmsi/xxxx/", "/cmsi/xxxxx"]}
-EXCLUDE_CUSTOM_CHANNEL_WHEN_SYNC = os.getenv("BK_ESB_EXCLUDE_CUSTOM_CHANNEL_WHEN_SYNC", "")
+# [{"method": "get", "path": "/cmsi/send_xxxx"}]
+EXCLUDE_OFFICIAL_CHANNELS_WHEN_SYNCING = env.list("BK_ESB_EXCLUDE_OFFICIAL_CHANNELS_WHEN_SYNCING", default=[])

--- a/paas2/esb/conf/default.py
+++ b/paas2/esb/conf/default.py
@@ -12,7 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-import json
 import environ
 from django.conf.global_settings import *  # noqa F403,F401
 

--- a/paas2/esb/conf/default.py
+++ b/paas2/esb/conf/default.py
@@ -12,7 +12,7 @@ specific language governing permissions and limitations under the License.
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-
+import json
 import environ
 from django.conf.global_settings import *  # noqa F403,F401
 
@@ -279,3 +279,7 @@ ESB_ALL_BUFFET_COMPONENTS_CACHE_MAXSIZE = 10
 ESB_ALL_BUFFET_COMPONENTS_CACHE_TTL_SECONDS = 300
 ESB_BUFFET_COMPONENT_CACHE_MAXSIZE = 1000
 ESB_BUFFET_COMPONENT_CACHE_TTL_SECONDS = 300
+
+# 从环境变量获取同步通道数据时豁免的自定义通道列表，格式为：
+# {"CMSI": ["/cmsi/xxxx/", "/cmsi/xxxxx"]}
+EXCLUDE_CUSTOM_CHANNEL_WHEN_SYNC = os.getenv("BK_ESB_EXCLUDE_CUSTOM_CHANNEL_WHEN_SYNC", "")

--- a/paas2/esb/esb/bkcore/managers.py
+++ b/paas2/esb/esb/bkcore/managers.py
@@ -15,11 +15,8 @@ from components.constants import BK_SYSTEMS
 
 
 class ComponentSystemManager(models.Manager):
-    def get_official_ids(self, exclude_names=None):
-        system_objs = self.filter(name__in=BK_SYSTEMS.keys())
-        if exclude_names:
-            system_objs = system_objs.exclude(name__in=exclude_names)
-        return list(system_objs.values_list("id", flat=True))
+    def get_official_ids(self):
+        return list(self.filter(name__in=BK_SYSTEMS.keys()).values_list("id", flat=True))
 
 
 class ESBChannelManager(models.Manager):

--- a/paas2/esb/esb/bkcore/managers.py
+++ b/paas2/esb/esb/bkcore/managers.py
@@ -15,8 +15,11 @@ from components.constants import BK_SYSTEMS
 
 
 class ComponentSystemManager(models.Manager):
-    def get_official_ids(self):
-        return list(self.filter(name__in=BK_SYSTEMS.keys()).values_list("id", flat=True))
+    def get_official_ids(self, exclude_names=None):
+        system_objs = self.filter(name__in=BK_SYSTEMS.keys())
+        if exclude_names:
+            system_objs = system_objs.exclude(name__in=exclude_names)
+        return list(system_objs.values_list("id", flat=True))
 
 
 class ESBChannelManager(models.Manager):

--- a/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
+++ b/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
@@ -15,7 +15,6 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
-from django.db.models import Q
 
 from common.constants import API_TYPE_Q
 from esb.bkcore.models import ComponentSystem, ESBBuffetComponent, ESBChannel, SystemDocCategory

--- a/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
+++ b/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
@@ -14,6 +14,8 @@ import json
 import logging
 
 from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.db.models import Q
 
 from common.constants import API_TYPE_Q
 from esb.bkcore.models import ComponentSystem, ESBBuffetComponent, ESBChannel, SystemDocCategory
@@ -111,7 +113,11 @@ class Command(BaseCommand):
         default_update_fields = ["name", "component_codename", "component_name", "method", "is_hidden"]
         force_update_fields = ["component_system_id", "type", "timeout_time"]
 
-        remaining_official_channel_ids = self._get_official_channel_ids()
+        # 获取需要豁免sync的自定义通道
+        exclude_custom_channel_ids = self._get_exclude_custom_channel_ids()
+        official_channel_ids = self._get_official_channel_ids()
+        # 官方通道列表，需排除掉豁免的自定义通道
+        remaining_official_channel_ids = list(set(official_channel_ids) - set(exclude_custom_channel_ids))
         remaining_official_channels = dict.fromkeys(remaining_official_channel_ids, None)
 
         conf_client = conf_tools.ConfClient()
@@ -238,10 +244,34 @@ class Command(BaseCommand):
 
     def _get_official_channel_ids(self):
         # CMSI下如果有自定义消息通道，会导致自定义通道也被识别为官方通道。因此这里要过滤掉CMSI
-        official_system_ids = ComponentSystem.objects.get_official_ids(exclude_names=["CMSI"])
+        official_system_ids = ComponentSystem.objects.get_official_ids()
         return list(
             ESBChannel.objects.filter(component_system_id__in=official_system_ids).values_list("id", flat=True)
         )
 
     def _hide_channels(self, channel_ids):
         ESBChannel.objects.filter(id__in=channel_ids).update(is_hidden=True)
+
+    def _get_exclude_custom_channel_ids(self):
+        exclude_channels_config = settings.EXCLUDE_CUSTOM_CHANNEL_WHEN_SYNC
+        if not exclude_channels_config:
+            return []
+        try:
+            exclude_channels_config = json.loads(exclude_channels_config)
+        except Exception as e:
+            logger.error("EXCLUDE_CUSTOM_CHANNEL_WHEN_SYNC is not json format, please check!")
+            # 不直接抛出，避免esb 执行命令异常而中断。
+            exclude_channels_config = {}
+
+        filter_qs = Q()
+        for system, paths in exclude_channels_config.items():
+            if not isinstance(paths, list):
+                continue
+            try:
+                system_obj = ComponentSystem.objects.get(name=system)
+            except ComponentSystem.DoesNotExist:
+                continue
+            filter_qs = filter_qs | (Q(component_system=system_obj) & Q(path__in=paths))
+        if not filter_qs:
+            return []
+        return list(ESBChannel.objects.filter(filter_qs).values_list("id", flat=True))

--- a/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
+++ b/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
@@ -243,7 +243,6 @@ class Command(BaseCommand):
             self.warning_msgs.append("%s change: %s" % (flag, ", ".join(warning)))
 
     def _get_official_channel_ids(self):
-        # CMSI下如果有自定义消息通道，会导致自定义通道也被识别为官方通道。因此这里要过滤掉CMSI
         official_system_ids = ComponentSystem.objects.get_official_ids()
         return list(
             ESBChannel.objects.filter(component_system_id__in=official_system_ids).values_list("id", flat=True)

--- a/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
+++ b/paas2/esb/esb/management/commands/sync_system_and_channel_data.py
@@ -237,7 +237,8 @@ class Command(BaseCommand):
             self.warning_msgs.append("%s change: %s" % (flag, ", ".join(warning)))
 
     def _get_official_channel_ids(self):
-        official_system_ids = ComponentSystem.objects.get_official_ids()
+        # CMSI下如果有自定义消息通道，会导致自定义通道也被识别为官方通道。因此这里要过滤掉CMSI
+        official_system_ids = ComponentSystem.objects.get_official_ids(exclude_names=["CMSI"])
         return list(
             ESBChannel.objects.filter(component_system_id__in=official_system_ids).values_list("id", flat=True)
         )


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #1152 `, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- fix issue #1152 ：custom channel in CMSI will be hidden when exec sync
增加环境变量：BK_ESB_EXCLUDE_CUSTOM_CHANNEL_WHEN_SYNC
paas2/esb/esb/management/commands/sync_system_and_channel_data.py 中变更部分代码，在执行时从官方通道列表中过滤掉部分自定义通道。
## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)

